### PR TITLE
Add HTTPS settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
     image: nginx:alpine
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./ssl:/etc/nginx/ssl
     depends_on:
       - frontend
       - app

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,23 @@ http {
     
     server {
         listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
         client_max_body_size 10M;
+
+        # SSL Certificates
+        ssl_certificate /etc/nginx/ssl/fullchain.pem;
+        ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+        # Basic SSL Configuration
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
         
         # Frontend routes
         location / {

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -1,0 +1,8 @@
+# SSL Certificates
+
+Please place your SSL certificates in this directory before starting the application:
+
+1. `fullchain.pem` - The full certificate chain
+2. `privkey.pem` - The private key
+
+The `nginx` container is configured to look for these files at `/etc/nginx/ssl/fullchain.pem` and `/etc/nginx/ssl/privkey.pem` respectively. If they are missing, the nginx container may fail to start.


### PR DESCRIPTION
feat: add HTTPS support and SSL configuration

- Configure Nginx to listen on port 443 with SSL certificates
- Redirect all HTTP (port 80) traffic to HTTPS
- Update docker-compose.yml to expose port 443 on the nginx service
- Mount local ./ssl directory to /etc/nginx/ssl for certificate management
- Add README instructions for placing SSL certificates